### PR TITLE
Features/aws volumes fc

### DIFF
--- a/src/main/resources/META-INF/plugin.yml
+++ b/src/main/resources/META-INF/plugin.yml
@@ -1,4 +1,4 @@
-id: alien-cloudify-3-orchestrator
+id: alien-cloudify-3-orchestrator-volume
 name: Cloudify 3 Orchestrator Plugin
 version: ${project.version}
 description: >

--- a/src/main/resources/provider/amazon/configuration/types.yaml
+++ b/src/main/resources/provider/amazon/configuration/types.yaml
@@ -113,4 +113,4 @@ node_types:
       This represents a Block Storage (Volume) instance on AWS. Cloudify 3 can create this block but will not delete it when the application is undeployed.
       In case the volume is created, it's id will be injected back into alien's deployment topology so next deployment reuse it.
     tags:
-      _a4c_persistent_resource_id: "external_id=volume_id"
+      _a4c_persistent_resource_id: "aws_resource_id=volume_id"

--- a/src/main/resources/provider/amazon/configuration/types.yaml
+++ b/src/main/resources/provider/amazon/configuration/types.yaml
@@ -102,6 +102,8 @@ node_types:
         default: "standard"
         constrainsts:
           - valid_values: [ "standard", "io1", "gp2" ]
+    attributes:
+      device: { get_attribute: [SELF, device] }
     tags:
       _a4c_c3_derived_from: cloudify.aws.nodes.Volume
       _a4c_c3_prop_map: >

--- a/src/main/resources/provider/amazon/configuration/types.yaml
+++ b/src/main/resources/provider/amazon/configuration/types.yaml
@@ -90,3 +90,27 @@ node_types:
       _a4c_c3_derived_from: cloudify.aws.nodes.ElasticIP
       _a4c_c3_floating_ip_prop_map: >
         {"cidr": null, "ip_version": null, "network_id": null, "gateway_ip": null, "network_name": null}
+
+  alien.cloudify.aws.nodes.DeletableVolume:
+    derived_from: tosca.nodes.BlockStorage
+    description: >
+      This represents a Block Storage (Volume) instance on AWS. Cloudify 3 can create this block and will delete it when the application is undeployed,
+      even if the volume id is provided.
+    properties:
+      volume_type:
+        type: string
+        default: "standard"
+        constrainsts:
+          - valid_values: [ "standard", "io1", "gp2" ]
+    tags:
+      _a4c_c3_derived_from: cloudify.aws.nodes.Volume
+      _a4c_c3_prop_map: >
+        {"size": {"path": "size", "unit": "GiB"}, "volume_id": "resource_id"}
+
+  alien.cloudify.aws.nodes.Volume:
+    derived_from: alien.cloudify.aws.nodes.DeletableVolume
+    description: >
+      This represents a Block Storage (Volume) instance on AWS. Cloudify 3 can create this block but will not delete it when the application is undeployed.
+      In case the volume is created, it's id will be injected back into alien's deployment topology so next deployment reuse it.
+    tags:
+      _a4c_persistent_resource_id: "external_id=volume_id"

--- a/src/main/resources/provider/amazon/volume_node.yaml.vm
+++ b/src/main/resources/provider/amazon/volume_node.yaml.vm
@@ -1,0 +1,23 @@
+#foreach($volumeTemplate in ${deployment.volumes})
+  ${volumeTemplate.id}:
+    type: ${volumeTemplate.nodeTemplate.type}
+#if(${volumeTemplate.nodeTemplate.type}=="alien.cloudify.aws.nodes.Volume")
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        delete: {}
+#end## if
+    properties: ${util.natives.formatProperties(3, $volumeTemplate.nodeTemplate.properties, $deployment.propertyMappings.get($volumeTemplate.nodeTemplate.type))}
+#if(${util.natives.hasPropertyValue($volumeTemplate.nodeTemplate.properties, "volume_id")})
+      use_external_resource: true
+#end## if
+#set( $relationshipTemplates = $util.nonNative.getSourceRelationships($volumeTemplate) )
+#if($util.collectionHasElement($relationshipTemplates))
+    relationships:
+#foreach($relationship in $relationshipTemplates)
+#if(${relationship.indexedToscaElement.elementId}=="tosca.relationships.AttachTo")
+      - target: $relationship.relationshipTemplate.target
+        type: cloudify.aws.relationships.volume_attached_to_instance
+#end## if
+#end## foreach($relationship in $relationshipTemplates)
+#end## if $util.collectionHasElement($relationshipTemplates)
+#end## foreach deployment.volumes


### PR DESCRIPTION
# Volume management for AWS

The code implements a patch to manage volume with A4C on AWS. The feature is based on the AWS plugin for Cloudify 3.2.1 developed by [Fastconnect](https://github.com/fastconnect/cloudify-aws-plugin/tree/1.2.1-build).

In order to use the patch, you will need to change the imports in your orchestration configuration to use the new [plugin.yaml](https://raw.githubusercontent.com/fastconnect/cloudify-aws-plugin/1.2.1-build/plugin.yaml) file.

> Note that you have to make the file available through Internet to be able to use it.

![add_custom_plugin](https://cloud.githubusercontent.com/assets/9881297/11370939/2edf9fd0-92c6-11e5-9d2a-aa7b2aba8e20.PNG)

You can now create Volume and DeletableVolume for your application!

**/!\ ATTENTION:** the **device** property is required on AWS! Be really careful when you set the property as AWS is really restrictive with attachment. Check the volume [documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html) for more information. Hence, the use of file system can be tricky as the device name you give to Cloudify is not necessarily the real one.

![volume_topology](https://cloud.githubusercontent.com/assets/9881297/11371267/ee7b09a0-92c7-11e5-83a6-1ce044bfbc96.PNG)
