### PR TITLE
Handle SSL protocol with the cloudify rest client

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Explicitly declare files to always takes the linux line endings on checkout.
+*.sh   text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf

--- a/src/main/resources/recipe/monitor/scripts/policy-start.sh
+++ b/src/main/resources/recipe/monitor/scripts/policy-start.sh
@@ -24,7 +24,7 @@ CRON_FILE=$MONITORING_DIR/policycron
 rm $CRON_FILE
 rm $MONITORING_DIR/log
 
-COMMAND="/root/${DPLID}/env/bin/python ${LOC} \"${NTM}\" ${DPLID} $MONITORING_DIR >> $MONITORING_DIR/log"
+COMMAND="/root/${DPLID}/env/bin/python ${LOC} \"${NTM}\" ${DPLID} $MONITORING_DIR >> $MONITORING_DIR/log 2>&1"
 echo "*/$MONITORING_INTERVAL * * * * $COMMAND" >> $CRON_FILE
 
 (crontab -l ; cat $CRON_FILE) 2>&1 | grep -v "no crontab" | sort | uniq | crontab -

--- a/src/main/resources/recipe/monitor/scripts/policy.py
+++ b/src/main/resources/recipe/monitor/scripts/policy.py
@@ -14,13 +14,27 @@ import datetime
 # change status of missing nodes comparing to the node_instances that are taken from cloudify
 # do it only for compute nodes
 
+def is_ssl_enabled():
+  # Since this script is executed from the manager machine, it searches directly into the rest-security configuration file to find out if the rest is secured.
+  rest_conf_file = '/opt/manager/rest-security.conf'
+  if not path.isfile(rest_conf_file):
+    return False
+  rest_conf = json.loads(open(rest_conf_file).read())
+  if 'ssl' in rest_conf and 'enabled' in rest_conf['ssl'] and rest_conf['ssl']['enabled'] == True:
+    return True
+  return False
+
+def log(message, level='INFO'):
+  print "{date} [{level}] {message}".format(date=str(datetime.datetime.now()), level=level, message=message)
 
 def check_liveness(nodes_to_monitor,depl_id):
-  c = CloudifyClient('localhost')
+  if is_ssl_enabled():
+    c = CloudifyClient(host='localhost', port=8101, protocol='https', trust_all=True)
+  else:
+    c = CloudifyClient(host='localhost')
+
   c_influx = InfluxDBClient(host='localhost', port=8086, database='cloudify')
-  print ('in check_liveness\n')
-  print ('nodes_to_monitor: {0}\n'.format(nodes_to_monitor))
-  c = CloudifyClient('localhost')
+  log ('nodes_to_monitor: {0}'.format(nodes_to_monitor))
 
   # compare influx data (monitoring) to cloudify desired state
 
@@ -29,36 +43,36 @@ def check_liveness(nodes_to_monitor,depl_id):
       for instance in instances:
           q_string='SELECT MEAN(value) FROM /' + depl_id + '\.' + node_name + '\.' + instance.id + '\.cpu_total_system/ GROUP BY time(10s) '\
                    'WHERE  time > now() - 40s'
-          print ('query string is {0}\n'.format(q_string))
+          log ('query string is {0}'.format(q_string))
           try:
              result=c_influx.query(q_string)
-             print ('result is {0} \n'.format(result))
+             log ('result is {0}'.format(result))
              if not result:
                executions=c.executions.list(depl_id)
                has_pending_execution = False
                if executions and len(executions)>0:
                  for execution in executions:
-                #    print("Execution {0} : {1}".format(execution.id, execution.status))
+                #    log("Execution {0} : {1}".format(execution.id, execution.status))
                    if execution.status not in execution.END_STATES:
                      has_pending_execution = True
 
                if not has_pending_execution:
-                 print ('Setting state to error for instance {0} and its children'.format(instance.id))
+                 log ('Setting state to error for instance {0} and its children'.format(instance.id))
                  update_nodes_tree_state(c, depl_id, instance, 'error')
                  params = {'node_instance_id': instance.id}
-                 print ('Calling Auto-healing workflow for container instance {0}'.format(instance.id))
+                 log ('Calling Auto-healing workflow for container instance {0}'.format(instance.id))
                  c.executions.start(depl_id, 'a4c_heal', params)
                else:
-                 print ('pendding executions on the deployment...waiting for their end before calling heal workfllow...')
+                 log ('pendding executions on the deployment...waiting for their end before calling heal workfllow...')
           except InfluxDBClientError as ee:
-             print ('DBClienterror {0}\n'.format(str(ee)))
-             print ('instance id is {0}\n'.format(instance))
+             log ('DBClienterror {0}'.format(str(ee)), level='ERROR')
+             log ('instance id is {0}'.format(instance), level='ERROR')
           except Exception as e:
-             print (str(e))
+             log (str(e), level='ERROR')
 
 
 def update_nodes_tree_state(client,depl_id,instance,state):
-  print ('updating instance {0} state to {1}'.format(instance.id, state))
+  log ('updating instance {0} state to {1}'.format(instance.id, state))
   client.node_instances.update(instance.id, state)
   dep_inst_list = client.node_instances.list(depl_id)
   for inst in dep_inst_list:
@@ -70,13 +84,12 @@ def update_nodes_tree_state(client,depl_id,instance,state):
           if ('contained_in' in str(type)) and (target == instance.node_id):
             update_nodes_tree_state(client,depl_id,inst,state)
     except Exception as e:
-      print(str(e))
+      log(str(e), level='ERROR')
 
 
 
 def main(argv):
-    for i in range(len(argv)):
-       print ("argv={0}\n".format(argv[i]))
+    log ("argv={0}".format(argv))
     depl_id=argv[2]
     monitoring_dir=argv[3]
     of = open(monitoring_dir+'/pid_file', 'w')

--- a/src/main/resources/recipe/velocity/includes/script_wrapper_static.py
+++ b/src/main/resources/recipe/velocity/includes/script_wrapper_static.py
@@ -12,8 +12,10 @@ from StringIO import StringIO
 from cloudify_rest_client import CloudifyClient
 from cloudify import utils
 
-client = CloudifyClient(utils.get_manager_ip(), utils.get_manager_rest_service_port())
-
+if os.environ['MANAGER_REST_PROTOCOL'] == "https":
+  client = CloudifyClient(host=utils.get_manager_ip(), port=utils.get_manager_rest_service_port(), protocol='https', trust_all=True)
+else:
+  client = CloudifyClient(host=utils.get_manager_ip(), port=utils.get_manager_rest_service_port())
 
 def convert_env_value_to_string(envDict):
     for key, value in envDict.items():

--- a/src/main/resources/recipe/velocity/mapping.py.vm
+++ b/src/main/resources/recipe/velocity/mapping.py.vm
@@ -35,9 +35,6 @@ def map_device_name(iaas, os_mapping, device_name):
     new_device_name = do_mapping(current_os, iaas, device_name)
   return new_device_name
 
-
-client = CloudifyClient(utils.get_manager_ip(), utils.get_manager_rest_service_port())
-
 # Retrieve requiert parameters
 volume_instance_id = inputs['volume_instance_id']
 iaas = inputs['iaas'] # correspond to the folder where to find the mapping scripts


### PR DESCRIPTION
- Changed CloudifyClient to handle HTTPS (trust_all only)

The PR also include:
- Improvement of the log output for the liveness checks (policy.py & policy-start.sh)
- .gitattribute for linux line endings
