### PR TITLE
Catch error if MANAGER_REST_PROTOCOL env var, does not exist

### DIFF
--- a/src/main/resources/recipe/velocity/includes/script_wrapper_static.py
+++ b/src/main/resources/recipe/velocity/includes/script_wrapper_static.py
@@ -12,10 +12,14 @@ from StringIO import StringIO
 from cloudify_rest_client import CloudifyClient
 from cloudify import utils
 
-if os.environ['MANAGER_REST_PROTOCOL'] == "https":
-  client = CloudifyClient(host=utils.get_manager_ip(), port=utils.get_manager_rest_service_port(), protocol='https', trust_all=True)
-else:
-  client = CloudifyClient(host=utils.get_manager_ip(), port=utils.get_manager_rest_service_port())
+try:
+    if os.environ['MANAGER_REST_PROTOCOL'] == "https":
+        client = CloudifyClient(host=utils.get_manager_ip(), port=utils.get_manager_rest_service_port(), protocol='https', trust_all=True)
+    else:
+        client = CloudifyClient(host=utils.get_manager_ip(), port=utils.get_manager_rest_service_port())
+except Exception, e:
+    print e
+    client = CloudifyClient(host=utils.get_manager_ip(), port=utils.get_manager_rest_service_port())
 
 def convert_env_value_to_string(envDict):
     for key, value in envDict.items():


### PR DESCRIPTION
When we try to deploy an application, the deployment fail because the environement variable MANAGER_REST_PROTOCOL does not exist, and in the cloudify recipe, the python script does not catch the exception.

Task failed 'script_runner.tasks.run' -> RecoverableError("KeyError: 'MANAGER_REST_PROTOCOL'",)
